### PR TITLE
Added valid_move? for queen

### DIFF
--- a/app/models/queen.rb
+++ b/app/models/queen.rb
@@ -1,5 +1,4 @@
-class Queen < Piece; 
-
+class Queen < Piece
   def valid_move?(destination_x, destination_y)
     return true if vertical_move?(destination_x) ||
                    horizontal_move?(destination_y) ||
@@ -9,5 +8,4 @@ class Queen < Piece;
                    diagonal_down_and_right_move?(destination_x, destination_y)
     false
   end
-
 end

--- a/app/models/queen.rb
+++ b/app/models/queen.rb
@@ -1,1 +1,13 @@
-class Queen < Piece; end
+class Queen < Piece; 
+
+  def valid_move?(destination_x, destination_y)
+    return true if vertical_move?(destination_x) ||
+                   horizontal_move?(destination_y) ||
+                   diagonal_up_and_left_move?(destination_x, destination_y) ||
+                   diagonal_down_and_left_move?(destination_x, destination_y) ||
+                   diagonal_up_and_right_move?(destination_x, destination_y) ||
+                   diagonal_down_and_right_move?(destination_x, destination_y)
+    false
+  end
+
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -57,4 +57,14 @@ FactoryGirl.define do
       row_coordinate 6
     end
   end
+
+  factory :queen do
+    association :game
+    association :user
+    trait :is_on_board do
+      is_on_board? true
+      column_coordinate 4
+      row_coordinate 4
+    end
+  end
 end

--- a/spec/models/queen_spec.rb
+++ b/spec/models/queen_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.describe Queen, type: :model do
+  let(:game) { FactoryGirl.create(:game) }
+  let(:user) { FactoryGirl.create(:user) }
+  let(:queen) { FactoryGirl.create(:queen, :is_on_board) }
+  
+  describe "queen#valid_move?" do
+    it "should return true for moves to the left" do
+      expect(queen.valid_move?(3, 4)).to eq(true)
+      expect(queen.valid_move?(1, 4)).to eq(true)
+    end
+
+    it "should return true for moves to the right" do
+      expect(queen.valid_move?(5, 4)).to eq(true)
+      expect(queen.valid_move?(7, 4)).to eq(true)
+    end
+
+    it "should return true for moves up" do
+      expect(queen.valid_move?(4, 5)).to eq(true)
+      expect(queen.valid_move?(4, 7)).to eq(true)
+    end
+
+    it "should return true for moves down" do
+      expect(queen.valid_move?(4, 3)).to eq(true)
+      expect(queen.valid_move?(4, 7)).to eq(true)
+    end
+
+    it "should return true for diagonal moves" do
+      expect(queen.valid_move?(6, 2)).to eq(true)
+      expect(queen.valid_move?(2, 2)).to eq(true)
+      expect(queen.valid_move?(6, 6)).to eq(true)
+      expect(queen.valid_move?(2, 6)).to eq(true)
+    end
+
+    it "should return false for moves that are not left, right, up, down, or in a diagonal" do
+      expect(queen.valid_move?(2, 3)).to eq(false)
+      expect(queen.valid_move?(3, 6)).to eq(false)
+    end
+  end
+
+
+end

--- a/spec/models/queen_spec.rb
+++ b/spec/models/queen_spec.rb
@@ -4,40 +4,38 @@ RSpec.describe Queen, type: :model do
   let(:game) { FactoryGirl.create(:game) }
   let(:user) { FactoryGirl.create(:user) }
   let(:queen) { FactoryGirl.create(:queen, :is_on_board) }
-  
-  describe "queen#valid_move?" do
-    it "should return true for moves to the left" do
+
+  describe 'queen#valid_move?' do
+    it 'should return true for moves to the left' do
       expect(queen.valid_move?(3, 4)).to eq(true)
       expect(queen.valid_move?(1, 4)).to eq(true)
     end
 
-    it "should return true for moves to the right" do
+    it 'should return true for moves to the right' do
       expect(queen.valid_move?(5, 4)).to eq(true)
       expect(queen.valid_move?(7, 4)).to eq(true)
     end
 
-    it "should return true for moves up" do
+    it 'should return true for moves up' do
       expect(queen.valid_move?(4, 5)).to eq(true)
       expect(queen.valid_move?(4, 7)).to eq(true)
     end
 
-    it "should return true for moves down" do
+    it 'should return true for moves down' do
       expect(queen.valid_move?(4, 3)).to eq(true)
       expect(queen.valid_move?(4, 7)).to eq(true)
     end
 
-    it "should return true for diagonal moves" do
+    it 'should return true for diagonal moves' do
       expect(queen.valid_move?(6, 2)).to eq(true)
       expect(queen.valid_move?(2, 2)).to eq(true)
       expect(queen.valid_move?(6, 6)).to eq(true)
       expect(queen.valid_move?(2, 6)).to eq(true)
     end
 
-    it "should return false for moves that are not left, right, up, down, or in a diagonal" do
+    it 'should return false for moves that are not left, right, up, down, or in a diagonal' do
       expect(queen.valid_move?(2, 3)).to eq(false)
       expect(queen.valid_move?(3, 6)).to eq(false)
     end
   end
-
-
 end

--- a/spec/models/queen_spec.rb
+++ b/spec/models/queen_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Queen, type: :model do
   let(:user) { FactoryGirl.create(:user) }
   let(:queen) { FactoryGirl.create(:queen, :is_on_board) }
 
-  describe 'queen#valid_move?' do
+  describe '#valid_move?' do
     it 'should return true for moves to the left' do
       expect(queen.valid_move?(3, 4)).to eq(true)
       expect(queen.valid_move?(1, 4)).to eq(true)


### PR DESCRIPTION
I added tests in queen_spec.rb to check movement in each direction as well as several cases that should be false.  The queen has a current position of (4, 4).  All tests are passing.

In queen.rb, I added the logic to test for a valid_move using the methods in piece.rb for each direction:

```
def valid_move?(destination_x, destination_y)
    return true if vertical_move?(destination_x) ||
                   horizontal_move?(destination_y) ||
                   diagonal_up_and_left_move?(destination_x, destination_y) ||
                   diagonal_down_and_left_move?(destination_x, destination_y) ||
                   diagonal_up_and_right_move?(destination_x, destination_y) ||
                   diagonal_down_and_right_move?(destination_x, destination_y)
    false
  end
```