### PR TITLE
Added valid move? and obstructed? check to move_to method

### DIFF
--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -12,7 +12,7 @@ class Piece < ApplicationRecord
 
   def move_to!(destination_x, destination_y)
     destination_piece = game.pieces.find_by(column_coordinate: destination_x, row_coordinate: destination_y, is_on_board?: true)
-    raise 'Invalid Move' if destination_piece.present? && !capturable?(destination_piece)
+    raise 'Invalid Move' if (destination_piece.present? && !capturable?(destination_piece)) || !valid_move?(destination_x, destination_y) || !obstructed?(destination_x, destination_y)
     if destination_piece.nil?
       move_to_empty_space(destination_x: destination_x, destination_y: destination_y)
     else

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -82,5 +82,13 @@
               };
       }
 
+      function move(column_coordinate, row_coordinate){
+        if (pieceId.valid_move?(column_coordinate, row_coordinate)) && (!pieceId.obstructed?(column_coordinate, row_coordinate)) {
+          pieceId.move_to!(column_coordinate, row_coordinate)
+        } else {
+          raise 'Error: Invalid Input'
+        }
+      }
+
   });
 </script>

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -47,7 +47,6 @@ FactoryGirl.define do
   factory :knight do
     association :game
     association :user
-
     trait :is_on_board do
       is_on_board? true
       column_coordinate 2
@@ -82,6 +81,16 @@ FactoryGirl.define do
       is_on_board? true
       column_coordinate 3
       row_coordinate 3
+    end
+  end
+
+  factory :rook do
+    trait :is_on_board do
+      association :game
+      association :user
+      is_on_board? true
+      column_coordinate 4
+      row_coordinate 4
     end
   end
 end

--- a/spec/models/bishop_spec.rb
+++ b/spec/models/bishop_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Bishop, type: :model do
   let(:game) { FactoryGirl.create(:game) }
   let(:user) { FactoryGirl.create(:user) }
-  let(:bishop) { FactoryGirl.create(:bishop, :is_on_board) }
+  let(:bishop) { FactoryGirl.create(:bishop, :is_on_board, color: 'black', game: game) }
   describe 'movement of bishop' do
     it 'should only move diagonally' do
       expect(bishop.valid_move?(2, 2)).to eq true
@@ -21,6 +21,28 @@ RSpec.describe Bishop, type: :model do
       expect(bishop.valid_move?(3, 4)).to eq false
       expect(bishop.valid_move?(3, 2)).to eq false
       expect(bishop.valid_move?(3, 4)).to eq false
+    end
+  end
+  describe '#move_to!' do
+    context 'when a move is invalid' do
+      it 'should raise error: Invalid Move' do
+        expect { bishop.move_to!(2, 3) }.to raise_error('Invalid Move')
+        expect { bishop.move_to!(4, 3) }.to raise_error('Invalid Move')
+        expect { bishop.move_to!(3, 2) }.to raise_error('Invalid Move')
+        expect { bishop.move_to!(3, 4) }.to raise_error('Invalid Move')
+      end
+    end
+    context 'when a move is obstructed' do
+      it 'should raise error, when obstructed horizontally/vertically' do
+        FactoryGirl.create(:queen, :is_on_board, color: 'black', game: game, row_coordinate: 4, column_coordinate: 4)
+        FactoryGirl.create(:queen, :is_on_board, color: 'black', game: game, row_coordinate: 2, column_coordinate: 2)
+        FactoryGirl.create(:queen, :is_on_board, color: 'black', game: game, row_coordinate: 4, column_coordinate: 2)
+        FactoryGirl.create(:queen, :is_on_board, color: 'black', game: game, row_coordinate: 2, column_coordinate: 4)
+        expect { bishop.move_to!(4, 4) }.to raise_error('Invalid Move')
+        expect { bishop.move_to!(2, 2) }.to raise_error('Invalid Move')
+        expect { bishop.move_to!(4, 2) }.to raise_error('Invalid Move')
+        expect { bishop.move_to!(2, 4) }.to raise_error('Invalid Move')
+      end
     end
   end
 end

--- a/spec/models/king_spec.rb
+++ b/spec/models/king_spec.rb
@@ -3,8 +3,7 @@ require 'rails_helper'
 RSpec.describe King, type: :model do
   let(:game) { FactoryGirl.create(:game) }
   let(:user) { FactoryGirl.create(:user) }
-  let(:king) { FactoryGirl.create(:king, :is_on_board) }
-
+  let(:king) { FactoryGirl.create(:king, :is_on_board, color: 'black', game: game) }
   describe 'movement of the king' do
     it 'should be able to move one field down' do
       expect(king.valid_move?(4, 3)).to eq true
@@ -22,10 +21,43 @@ RSpec.describe King, type: :model do
       expect(king.valid_move?(3, 5)).to eq true
       expect(king.valid_move?(5, 5)).to eq true
       expect(king.valid_move?(3, 3)).to eq true
-      expect(king.valid_move?(3, 5)).to eq true
+      expect(king.valid_move?(5, 3)).to eq true
     end
     it 'should return false if it moves more than field' do
       expect(king.valid_move?(4, 6)).to eq false
+    end
+  end
+  describe '#move_to!' do
+    context 'when a move is invalid' do
+      it 'should raise error: Invalid Move' do
+        expect { king.move_to!(2, 4) }.to raise_error('Invalid Move')
+        expect { king.move_to!(6, 4) }.to raise_error('Invalid Move')
+        expect { king.move_to!(4, 2) }.to raise_error('Invalid Move')
+        expect { king.move_to!(4, 6) }.to raise_error('Invalid Move')
+        expect { king.move_to!(3, 3) }.to raise_error('Invalid Move')
+      end
+    end
+    context 'when a move is obstructed' do
+      it 'should raise error, when obstructed horizontally/vertically' do
+        FactoryGirl.create(:bishop, :is_on_board, color: 'black', game: game, row_coordinate: 4, column_coordinate: 3)
+        FactoryGirl.create(:bishop, :is_on_board, color: 'black', game: game, row_coordinate: 4, column_coordinate: 5)
+        FactoryGirl.create(:bishop, :is_on_board, color: 'black', game: game, row_coordinate: 3, column_coordinate: 4)
+        FactoryGirl.create(:bishop, :is_on_board, color: 'black', game: game, row_coordinate: 5, column_coordinate: 4)
+        expect { king.move_to!(4, 3) }.to raise_error('Invalid Move')
+        expect { king.move_to!(4, 5) }.to raise_error('Invalid Move')
+        expect { king.move_to!(3, 4) }.to raise_error('Invalid Move')
+        expect { king.move_to!(5, 4) }.to raise_error('Invalid Move')
+      end
+      it 'should raise error, when obstructed diagonally' do
+        FactoryGirl.create(:bishop, :is_on_board, color: 'black', game: game, row_coordinate: 3, column_coordinate: 3)
+        FactoryGirl.create(:bishop, :is_on_board, color: 'black', game: game, row_coordinate: 3, column_coordinate: 5)
+        FactoryGirl.create(:bishop, :is_on_board, color: 'black', game: game, row_coordinate: 5, column_coordinate: 5)
+        FactoryGirl.create(:bishop, :is_on_board, color: 'black', game: game, row_coordinate: 5, column_coordinate: 3)
+        expect { king.move_to!(3, 3) }.to raise_error('Invalid Move')
+        expect { king.move_to!(3, 5) }.to raise_error('Invalid Move')
+        expect { king.move_to!(5, 5) }.to raise_error('Invalid Move')
+        expect { king.move_to!(5, 3) }.to raise_error('Invalid Move')
+      end
     end
   end
 end

--- a/spec/models/knight_spec.rb
+++ b/spec/models/knight_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Knight, type: :model do
   let(:game) { FactoryGirl.create(:game) }
-  let(:knight) { FactoryGirl.create(:knight, :is_on_board, game_id: game.id) }
+  let(:knight) { FactoryGirl.create(:knight, :is_on_board, color: 'black', game: game) }
 
   describe '#valid_move?' do
     context 'moving up and right' do
@@ -44,6 +44,20 @@ RSpec.describe Knight, type: :model do
     context 'invalid move' do
       it 'returns false' do
         expect(knight.valid_move?(5, 5)).to eq false
+      end
+    end
+  end
+  describe '#move_to!' do
+    context 'when a move is invalid' do
+      it 'should raise error: Invalid Move' do
+        expect { knight.move_to!(1, 3) }.to raise_error('Invalid Move')
+        expect { knight.move_to!(3, 3) }.to raise_error('Invalid Move')
+        expect { knight.move_to!(2, 4) }.to raise_error('Invalid Move')
+        expect { knight.move_to!(2, 5) }.to raise_error('Invalid Move')
+        expect { knight.move_to!(1, 4) }.to raise_error('Invalid Move')
+        expect { knight.move_to!(1, 2) }.to raise_error('Invalid Move')
+        expect { knight.move_to!(3, 4) }.to raise_error('Invalid Move')
+        expect { knight.move_to!(3, 2) }.to raise_error('Invalid Move')
       end
     end
   end

--- a/spec/models/pawn_spec.rb
+++ b/spec/models/pawn_spec.rb
@@ -63,4 +63,20 @@ RSpec.describe Pawn, type: :model do
       expect(pawn_black.valid_move?(0, 5)).to eq true
     end
   end
+  describe '#move_to!' do
+    context 'when a move is invalid' do
+      it 'should raise error: Invalid Move' do
+        expect { pawn_black.move_to!(0, 5) }.to raise_error('Invalid Move')
+        expect { pawn_black.move_to!(2, 5) }.to raise_error('Invalid Move')
+        expect { pawn_black.move_to!(0, 7) }.to raise_error('Invalid Move')
+        expect { pawn_black.move_to!(2, 7) }.to raise_error('Invalid Move')
+      end
+    end
+    context 'when a move is obstructed' do
+      it 'should raise error, when obstructed horizontally/vertically' do
+        FactoryGirl.create(:pawn, :is_on_board, color: 'black', column_coordinate: 5, game: game)
+        expect { pawn_black.move_to!(1, 5) }.to raise_error('Invalid Move')
+      end
+    end
+  end
 end

--- a/spec/models/piece_spec.rb
+++ b/spec/models/piece_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe Piece, type: :model do
       expect(piece_black.obstructed?(4, 7)).to eq false
     end
     it 'should return true if piece is between destination and origin when going down' do
-      FactoryGirl.create(:piece, column_coordinate: 4, row_coordinate: 2, is_on_board?: true, game: game)
+      FactoryGirl.create(:piece, column_coordinate: 4, row_coordinate: 2, is_on_board?: true, game: game.id)
       expect(piece_black.obstructed?(4, 0)).to eq true
     end
     it 'should return true if piece is between destination and origin when going up' do

--- a/spec/models/queen_spec.rb
+++ b/spec/models/queen_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Queen, type: :model do
   let(:game) { FactoryGirl.create(:game) }
   let(:user) { FactoryGirl.create(:user) }
-  let(:queen) { FactoryGirl.create(:queen, :is_on_board) }
+  let(:queen) { FactoryGirl.create(:queen, :is_on_board, color: 'black', game: game) }
 
   describe '#valid_move?' do
     it 'should return true for moves to the left' do
@@ -36,6 +36,30 @@ RSpec.describe Queen, type: :model do
     it 'should return false for moves that are not left, right, up, down, or in a diagonal' do
       expect(queen.valid_move?(2, 3)).to eq(false)
       expect(queen.valid_move?(3, 6)).to eq(false)
+    end
+  end
+  describe '#move_to!' do
+    context 'when a move is obstructed' do
+      it 'should raise error, when obstructed horizontally/vertically' do
+        FactoryGirl.create(:queen, :is_on_board, color: 'black', game: game, row_coordinate: 3)
+        FactoryGirl.create(:queen, :is_on_board, color: 'black', game: game, row_coordinate: 5)
+        FactoryGirl.create(:queen, :is_on_board, color: 'black', game: game, column_coordinate: 3)
+        FactoryGirl.create(:queen, :is_on_board, color: 'black', game: game, column_coordinate: 5)
+        expect { queen.move_to!(3, 4) }.to raise_error('Invalid Move')
+        expect { queen.move_to!(5, 4) }.to raise_error('Invalid Move')
+        expect { queen.move_to!(4, 3) }.to raise_error('Invalid Move')
+        expect { queen.move_to!(4, 5) }.to raise_error('Invalid Move')
+      end
+      it 'should raise error, when obstructed diagonally' do
+        FactoryGirl.create(:queen, :is_on_board, color: 'black', game: game, row_coordinate: 3, column_coordinate: 3)
+        FactoryGirl.create(:queen, :is_on_board, color: 'black', game: game, row_coordinate: 5, column_coordinate: 3)
+        FactoryGirl.create(:queen, :is_on_board, color: 'black', game: game, row_coordinate: 3, column_coordinate: 5)
+        FactoryGirl.create(:queen, :is_on_board, color: 'black', game: game, row_coordinate: 5, column_coordinate: 5)
+        expect { queen.move_to!(3, 3) }.to raise_error('Invalid Move')
+        expect { queen.move_to!(5, 3) }.to raise_error('Invalid Move')
+        expect { queen.move_to!(3, 5) }.to raise_error('Invalid Move')
+        expect { queen.move_to!(5, 5) }.to raise_error('Invalid Move')
+      end
     end
   end
 end

--- a/spec/models/rook_spec.rb
+++ b/spec/models/rook_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe Rook, type: :model do
+  let(:game) { FactoryGirl.create(:game) }
+  let(:user) { FactoryGirl.create(:user) }
+  let(:rook) { FactoryGirl.create(:queen, :is_on_board, color: 'black', game: game) }
+
+  describe '#move_to!' do
+    context 'when a move is obstructed' do
+      it 'should raise error, when obstructed horizontally/vertically' do
+        FactoryGirl.create(:rook, :is_on_board, color: 'black', game: game, row_coordinate: 3)
+        FactoryGirl.create(:rook, :is_on_board, color: 'black', game: game, row_coordinate: 5)
+        FactoryGirl.create(:rook, :is_on_board, color: 'black', game: game, column_coordinate: 3)
+        FactoryGirl.create(:rook, :is_on_board, color: 'black', game: game, column_coordinate: 5)
+        expect { rook.move_to!(3, 4) }.to raise_error('Invalid Move')
+        expect { rook.move_to!(5, 4) }.to raise_error('Invalid Move')
+        expect { rook.move_to!(4, 3) }.to raise_error('Invalid Move')
+        expect { rook.move_to!(4, 5) }.to raise_error('Invalid Move')
+      end
+    end
+  end
+end


### PR DESCRIPTION
1. In piece.rb, inside the move_to! method, I added checks for valid_move? and obstructed?
2. Configured Rspec tests for move_to! for each piece

Question: valid_move? is a method created for each piece. Since I piece.rb does not have access to the valid_move? method, we get errors in piece_spec.rb. This makes sense, since piece.rb does know about valid_move?. What should I do about the tests in piece_spec.rb? should they be taken out? commented out?