### PR TITLE
Fix board resizing

### DIFF
--- a/app/assets/stylesheets/master.scss
+++ b/app/assets/stylesheets/master.scss
@@ -52,6 +52,11 @@ body {
   background-size: cover;
 }
 
+.table {
+  min-width: 800px;
+  min-height: 800px;
+}
+
 .box {
   background-color: rgba(101, 171, 255, 0.39);
   color: white;

--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -28,6 +28,8 @@ class PiecesController < ApplicationController
       current_game.set_game_status
       Pusher.trigger('piece_moved_game' + @piece.game.id.to_s, 'piece_moved', message: flashmessages,
                                                                               turn: check_turn,
+                                                                              type: @piece.type,
+                                                                              color: @piece.color,
                                                                               row_destination: destination_y,
                                                                               column_destination: destination_x,
                                                                               row_origin: current_row,

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -204,8 +204,7 @@ class Piece < ApplicationRecord
   end
 
   def diagonal_obstruction_up_right?(destination_y)
-    ((row_coordinate + 1)..(destination_y - 1)).each_with_index do |row, index|
-      index += 1
+    ((row_coordinate + 1)..(destination_y - 1)).each.with_index(1) do |row, index|
       present_pieces_check = game.pieces.where(row_coordinate: row, column_coordinate: column_coordinate + index).present?
       return true if present_pieces_check
     end
@@ -222,8 +221,7 @@ class Piece < ApplicationRecord
   end
 
   def diagonal_obstruction_up_left?(destination_y)
-    ((row_coordinate + 1)..(destination_y - 1)).each_with_index do |row, index|
-      index += 1
+    ((row_coordinate + 1)..(destination_y - 1)).each.with_index(1) do |row, index|
       present_pieces_check = game.pieces.where(row_coordinate: row, column_coordinate: column_coordinate - index).present?
       return true if present_pieces_check
     end
@@ -231,9 +229,8 @@ class Piece < ApplicationRecord
   end
 
   def diagonal_obstruction_down_right?(destination_y)
-    ((destination_y + 1)..(row_coordinate - 1)).to_a.reverse.each_with_index do |row, index|
-      index += 1
-      present_pieces_check = game.pieces.where(row_coordinate: row, column_coordinate: column_coordinate + index).present?
+    ((destination_y + 1)..(row_coordinate - 1)).each.with_index(1) do |_row, index|
+      present_pieces_check = game.pieces.where(row_coordinate: row_coordinate - index, column_coordinate: column_coordinate + index).present?
       return true if present_pieces_check
     end
     false

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -105,9 +105,28 @@
     $("[row=" + data.row_origin + "][column=" + data.column_origin + "]").find("span").remove();
     piece.css('top', '');
     piece.css('left', '');
+    castling(data);
     makePiecesDraggable();
     change_turn(data.turn);
   });
+
+  function castling(data){
+    let rook_row = 0;
+    let rook_column = 0;
+    (data.color === "white") ?  rook_row = 0 : rook_row = 7;
+    (data.column_destination === 6) ? rook_column = 7 : rook_column = 0;
+    let rook = $("[row =" + rook_row + "][column =" + rook_column + "]").find("span");
+    if (data.type === "King" && data.column_destination === 6 && data.row_destination === data.row_origin && data.column_origin === 4){
+      $("[row =" + rook_row + "][column = 5]").append(rook);
+      $("[row =" + rook_row + "][column =" + rook_column + "]").find("span").remove();
+    }
+    if (data.type === "King" && data.column_destination === 2 && data.row_destination === data.row_origin && data.column_origin === 4){
+      $("[row =" + rook_row + "][column = 3]").append(rook);
+      $("[row =" + rook_row + "][column =" + rook_column + "]").find("span").remove();
+    }
+    rook.css('top', '');
+    rook.css('left', '');
+  };
 
   function makePiecesDraggable(){
     $(".chessboard .piece").draggable({

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -25,13 +25,15 @@
   </div>
   <br />
   <div class="row">
-    <div id="turn" class="col-1 offset-1">
+    <div id="turn" class="col-lg-1 col-md-12 text-center offset-1">
         <h4>Turn:</h4>
         <h5 id= "white_player_id" class="white_turn"><%= ("White: " + @game.white_player.name) unless @waiting%></h5></br>
         <h5 id= "black_player_id" class="black_turn"><%= ("Black: " + @game.black_player.name) unless @waiting%></h5></br>
         <%= image_tag gravatar_for(@game.turn == @game.white_player_id ? @game.white_player.email : @game.black_player.email )unless @waiting%>
     </div>
-    <div class="col-8">
+    <br class="clear"/>
+    <br class="clear"/>
+    <div class="col-lg-8 col-md-12 table">
       <% @board.reverse_each.with_index do |row, index_row| %>
           <%index_row = @board.length - index_row - 1 %>
           <div class = "row offset-2">

--- a/spec/models/bishop_spec.rb
+++ b/spec/models/bishop_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe Bishop, type: :model do
   let(:game) { FactoryGirl.create(:game) }
   let(:user) { FactoryGirl.create(:user) }
   let(:bishop) { FactoryGirl.create(:bishop, :is_on_board) }
+  let(:pawn) { FactoryGirl.create(:pawn, :is_on_board) }
   describe 'movement of bishop' do
     it 'should move diagonally up and left' do
       expect(bishop.valid_move?(2, 4)).to eq true


### PR DESCRIPTION
This branch fixes the board resizing. When you minimize your browser, the columns would overlap each other, messing up the view of the board.

I fixed this by setting a minimum width and height for the board.